### PR TITLE
fix: config newWathcer without opts parameters

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,49 +11,48 @@ import (
 const testKey = "/kratos/test/config"
 
 func TestConfig(t *testing.T) {
-	client, err := clientv3.New(clientv3.Config{Endpoints: []string{"127.0.0.1:2379"},  DialTimeout:time.Second})
-	if err != nil{
+	client, err := clientv3.New(clientv3.Config{Endpoints: []string{"127.0.0.1:2379"}, DialTimeout: time.Second})
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer client.Close()
 
-	if _, err = client.Put(context.Background(), testKey, "test config"); err!= nil{
+	if _, err = client.Put(context.Background(), testKey, "test config"); err != nil {
 		t.Fatal(err)
 	}
 
 	source, err := New(client, Path(testKey))
-	if err != nil{
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	kvs, err := source.Load()
-	if err != nil{
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(kvs) != 1 ||  kvs[0].Key != testKey || string(kvs[0].Value) != "test config"{
+	if len(kvs) != 1 || kvs[0].Key != testKey || string(kvs[0].Value) != "test config" {
 		t.Fatal("config error")
 	}
 
 	w, err := source.Watch()
-	if err != nil{
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer w.Stop()
 
 	go func() {
-		time.Sleep(time.Millisecond*10)
-		if _, err = client.Put(context.Background(), testKey, "new config"); err!= nil{
-			t.Fatal(err)
+		time.Sleep(time.Millisecond * 10)
+		if _, err = client.Put(context.Background(), testKey, "new config"); err != nil {
+			t.Error(err)
 		}
 	}()
 
-	if kvs, err = w.Next(); err != nil{
+	if kvs, err = w.Next(); err != nil {
 		t.Fatal(err)
 	}
 
-
-	if len(kvs) != 1 ||  kvs[0].Key != testKey || string(kvs[0].Value) != "new config"{
+	if len(kvs) != 1 || kvs[0].Key != testKey || string(kvs[0].Value) != "new config" {
 		t.Fatal("config error")
 	}
 

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -21,7 +21,7 @@ func newWatcher(s *source) *watcher {
 	if s.options.prefix {
 		opts = append(opts, clientv3.WithPrefix())
 	}
-	w.ch = s.client.Watch(s.options.ctx, s.options.path)
+	w.ch = s.client.Watch(s.options.ctx, s.options.path, opts...)
 
 	return w
 }


### PR DESCRIPTION
fix missing `opts` parameters when new a config Watcher and do some code clean up